### PR TITLE
Do not normalize local version labels

### DIFF
--- a/py2deb/tests.py
+++ b/py2deb/tests.py
@@ -161,6 +161,11 @@ class PackageConverterTestCase(TestCase):
         assert normalize_package_version('1.0b2') == '1.0~b2'
         assert normalize_package_version('1.0c2') == '1.0~rc2'
         assert normalize_package_version('1.0rc2') == '1.0~rc2'
+        # Do not modify local version labels
+        assert normalize_package_version('1.0+a2') == '1.0+a2'
+        assert normalize_package_version('1.0+b2') == '1.0+b2'
+        assert normalize_package_version('1.0+c2') == '1.0+c2'
+        assert normalize_package_version('1.0+65c43') == '1.0+65c43'
         # New versus old behavior (the option to control backwards compatibility was added in release 2.1).
         assert normalize_package_version('1.0a2', prerelease_workaround=True) == '1.0~a2'
         assert normalize_package_version('1.0a2', prerelease_workaround=False) == '1.0a2'

--- a/py2deb/utils.py
+++ b/py2deb/utils.py
@@ -364,8 +364,16 @@ def normalize_package_version(python_package_version, prerelease_workaround=True
     the identifier 'c' is translated into 'rc'. Refer to `issue #8
     <https://github.com/paylogic/py2deb/issues/8>`_ for details.
     """
+    # Do not normalize local version labels since these may contain strings
+    # such as SCM hashes that should not be altered. Split the version string
+    # into the primary version and the local version label and only operate
+    # on the primary version string.
+    version_parts = python_package_version.split('+', 2)
+    version = version_parts[0]
+    local_version_label = version_parts[1] if len(version_parts) == 2 else None
+
     # Lowercase and remove invalid characters from the version string.
-    version = re.sub('[^a-z0-9.+]+', '-', python_package_version.lower()).strip('-')
+    version = re.sub('[^a-z0-9.+]+', '-', version.lower()).strip('-')
     if prerelease_workaround:
         # Translate the PEP 440 pre-release identifier 'c' to 'rc'.
         version = re.sub(r'(\d)c(\d)', r'\1rc\2', version)
@@ -376,6 +384,9 @@ def normalize_package_version(python_package_version, prerelease_workaround=True
     if len(components) > 1 and not re.search('[0-9]', components[-1]):
         components.append('1')
         version = '-'.join(components)
+    # Join local version label back if it exists
+    if local_version_label:
+        version = version + '+' + local_version_label
     return version
 
 


### PR DESCRIPTION
As per [PEP440](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers):

```
Local version identifiers MUST comply with the following scheme:
  <public version identifier>[+<local version label>]

They consist of a normal public version identifier (as defined in the
previous section), along with an arbitrary "local version label",
separated from the public version identifier by a plus. Local version
labels have no specific semantics assigned, but some syntactic
restrictions are imposed.
```

Local version labels have no semantic meaning, so they should not be
normalized like the primary version identifier. This is important
for developers that may want to include an SCM hash in their version
via a local version label which might be altered by the current
`normalize_package_version` method.