### PR TITLE
Support for user provided Debian Maintainer

### DIFF
--- a/py2deb/package.py
+++ b/py2deb/package.py
@@ -138,11 +138,19 @@ class PackageToConvert(PropertyManager):
         The name and e-mail address are combined into a single string that can
         be embedded in a Debian package.
         """
-        maintainer = self.metadata.maintainer
-        maintainer_email = self.metadata.maintainer_email
-        if not maintainer:
+        if os.getenv("DEBFULLNAME"):
+            maintainer = os.getenv("DEBFULLNAME")
+            maintainer_email = os.getenv("DEBEMAIL")
+        elif self.metadata.maintainer:
+            maintainer = self.metadata.maintainer
+            maintainer_email = self.metadata.maintainer_email
+        elif self.metadata.author:
             maintainer = self.metadata.author
             maintainer_email = self.metadata.author_email
+        else:
+            maintainer = None
+            maintainer_email = None
+
         if maintainer and maintainer_email:
             return '%s <%s>' % (maintainer, maintainer_email.strip('<>'))
         else:


### PR DESCRIPTION
In Debian, the maintainer is usually defined with DEBFULLNAME and
DEBEMAIL env vars [1,2]. Update debian_maintainer property to take
this into account. If not set, it will continue to use the maintainer
or author as obtained from PKG-INFO of the Python package.

[1] https://manpages.debian.org/stretch/devscripts/devscripts.1.en.html#ENVIRONMENT
[2] https://www.debian.org/doc/manuals/maint-guide/first.en.html#dh-make

Signed-off-by: Dimitris Aragiorgis <dimara@arrikto.com>