### PR TITLE
docs: fix simple typo, feasability -> feasibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,7 +215,7 @@ in packages converted by py2deb and drop a few configuration files into place.
 Conversion of binary wheels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Investigate the feasability of supporting conversion of binary wheels. Slowly
+Investigate the feasibility of supporting conversion of binary wheels. Slowly
 but surely the Python community seems to be gravitating towards (binary) wheels
 and once gravity has shifted we don't want to be left in the dust! 😉
 


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `feasibility` rather than `feasability`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md